### PR TITLE
AB#6372 Invalid Login Credentials for Sitecore PowerShell

### DIFF
--- a/docker/build/cm/Data/transforms/web.config.cm.xdt
+++ b/docker/build/cm/Data/transforms/web.config.cm.xdt
@@ -10,4 +10,8 @@
       </httpProtocol>
     </system.webServer>
   </location>
+  <system.web>
+    <!-- Change the hash algorithm for password encryption - https://doc.sitecore.com/developers/91/platform-administration-and-architecture/en/change-the-hash-algorithm-for-password-encryption.html -->
+    <membership xdt:Transform="SetAttributes" xdt:Locator="Match(defaultProvider)" defaultProvider="sitecore" hashAlgorithmType="SHA512"/>
+  </system.web>
 </configuration>

--- a/docker/build/cm/Dockerfile
+++ b/docker/build/cm/Dockerfile
@@ -60,6 +60,9 @@ COPY ./Data/transforms/ /inetpub/wwwroot/transforms/
 # Copy solution website files
 COPY --from=solution /artifacts/sitecore/ ./
 
+# Fix for PowerShell Console failing to open from Sitecore desktop menu - Requires PSE to be installed
+RUN Rename-Item -Path 'C:\inetpub\wwwroot\App_Config\Include\Spe\Spe.IdentityServer.config.disabled' -NewName 'Spe.IdentityServer.config'
+
 # Perform transforms
 RUN (Get-ChildItem -Path 'C:\\inetpub\\wwwroot\\transforms\\web*.xdt' -Recurse ) | `
     ForEach-Object { & 'C:\\tools\\scripts\\Invoke-XdtTransform.ps1' -Path 'C:\\inetpub\\wwwroot\\web.config' -XdtPath $_.FullName `


### PR DESCRIPTION
- Updating hash to SHA512 via CM web.config transform
- Enabling the "Spe.IdentityServer.config.disabled" file to enable ability to run PSE from Desktop menu without error