### PR TITLE
AB#6246 handle words in breadcrumb

### DIFF
--- a/Website/src/rendering/src/assets/css/layout/breadcrumb.css
+++ b/Website/src/rendering/src/assets/css/layout/breadcrumb.css
@@ -7,6 +7,9 @@
 
     a {
       @apply text-sm;
+      &:hover {
+        @apply underline;
+      }
     }
   }
   li:not(:first-of-type):before {

--- a/Website/src/rendering/src/components/Breadcrumb.tsx
+++ b/Website/src/rendering/src/components/Breadcrumb.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import Breadcrumbs from 'nextjs-breadcrumbs';
 
+function formatBreadcrumb(text: string) {
+  text = decodeURIComponent(text);
+  text = text.replaceAll('-', ' ');
+  return text;
+}
+
 const Breadcrumb = (): JSX.Element => {
   return (
     <Breadcrumbs
@@ -8,8 +14,7 @@ const Breadcrumb = (): JSX.Element => {
       containerClassName="breadcrumb"
       inactiveItemClassName="inactive"
       listClassName="list"
-      useDefaultStyle
-      rootLabel="Home"
+      transformLabel={(title) => formatBreadcrumb(title)}
     />
   );
 };


### PR DESCRIPTION
decode breadcrumb
add underline on hover link
![image](https://user-images.githubusercontent.com/82103130/130546309-6dfe5ead-6cd7-488c-abb5-f2d89293a57a.png)
but if the page title is one word then it needs work.
![image](https://user-images.githubusercontent.com/82103130/130546387-727ab19b-11c5-454b-a419-7269e70b4e8f.png)
