### PR TITLE
AB#6518 Fix "Server cannot append header after HTTP headers have been sent." exceptions

### DIFF
--- a/.env
+++ b/.env
@@ -84,7 +84,6 @@ CMP_ServiceBusSubscription=
 CMP_ServiceBusEntityPathOut=
 DAM_ContentHub=
 DAM_SearchPage=
-DAM_ExternalRedirectKey=
 DAM_ExternalRedirectKey=Sitecore
 
 # CDP

--- a/Website/src/platform/App_Config/Include/Sitecore.Demo.Edge.Website.config
+++ b/Website/src/platform/App_Config/Include/Sitecore.Demo.Edge.Website.config
@@ -8,7 +8,7 @@
       <site name="shell">
         <patch:attribute name="contentStartItem">/EdgeWebsite/home</patch:attribute>
       </site>
-      
+
       <!--
         JSS Site Registration
         This configures the site with Sitecore - i.e. host headers, item paths.
@@ -74,7 +74,13 @@
           </getLayoutServiceContext>
         </pipelines>
       </group>
+      <!-- DEMO TEAM CUSTOMIZATION - Delete the requestEnd Horizon processor that adds the frame-ancestors content-security-policy. We instead included it in our own content-security-policy. -->
+      <mvc.requestEnd>
+        <processor type="Sitecore.Horizon.Integration.OnPrem.Pipelines.MvcRequestEnd.RegisterIFrameAllowedDomainsMvc, Sitecore.Horizon.Integration.OnPrem">
+          <patch:delete />
+        </processor>
+      </mvc.requestEnd>
+      <!-- END CUSTOMIZATION -->
     </pipelines>
-
   </sitecore>
 </configuration>

--- a/docker/build/cm/Data/transforms/web.config.cm.xdt
+++ b/docker/build/cm/Data/transforms/web.config.cm.xdt
@@ -4,8 +4,8 @@
     <system.webServer>
       <httpProtocol>
         <customHeaders>
-        <!-- CSP -->
-          <add xdt:Transform="SetAttributes" xdt:Locator="Match(name)" name="Content-Security-Policy" value="default-src 'self' 'unsafe-inline' 'unsafe-eval' https://apps.sitecore.net https://*.stylelabs.io https://*.stylelabs.cloud https://*.stylelabsdemo.com https://*.stylelabsqa.com https://*.stylelabsdev.com https://*.sitecoresandbox.cloud https://*.azureedge.net; img-src 'self' data: https://*.stylelabs.io https://*.stylelabs.cloud https://*.stylelabsdemo.com https://*.stylelabsqa.com https://*.stylelabsdev.com https://*.sitecoresandbox.cloud https://*.azureedge.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' 'unsafe-inline' https://fonts.gstatic.com;"/>
+          <!-- CSP -->
+          <add xdt:Transform="SetAttributes" xdt:Locator="Match(name)" name="Content-Security-Policy" value="default-src 'self' 'unsafe-inline' 'unsafe-eval' https://apps.sitecore.net https://*.stylelabs.io https://*.stylelabs.cloud https://*.stylelabsdemo.com https://*.stylelabsqa.com https://*.stylelabsdev.com https://*.sitecoresandbox.cloud https://*.azureedge.net https://stylelabs.eu.auth0.com https://login.windows.net https://login.microsoftonline.com; img-src 'self' data: https://*.stylelabs.io https://*.stylelabs.cloud https://*.stylelabsdemo.com https://*.stylelabsqa.com https://*.stylelabsdev.com https://*.sitecoresandbox.cloud https://*.azureedge.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' 'unsafe-inline' https://fonts.gstatic.com; frame-ancestors 'self' https://sh.edge.localhost https://*.sitecoredemo.com;"/>
         </customHeaders>
       </httpProtocol>
     </system.webServer>


### PR DESCRIPTION
Fix "Server cannot append header after HTTP headers have been sent." exceptions.
Also allow ContentHub login in the DAM image selection iframe.