### PR TITLE
AB#7092: Content not displayed for "Content Page" branch templates

### DIFF
--- a/Website/src/rendering/src/components/PageContent/Section.tsx
+++ b/Website/src/rendering/src/components/PageContent/Section.tsx
@@ -32,7 +32,7 @@ const Section = (props: SectionProps): JSX.Element => {
     <>
       <Text tag="h2" field={props.fields.title} className="section__content__title" />
       {props.fields.content && (
-        <RichText tag="p" field={props.fields.content} className="section__content__p" />
+        <RichText tag="div" field={props.fields.content} className="section__content__p" />
       )}
     </>
   );


### PR DESCRIPTION
The tag="p" parameter should no longer be used when outputting content for a RichText field. It can lead to nested paragraph tags which is not displayed due to invalid HTML.