### PR TITLE
AB#7301 Add Discover and OrderCloud environment variables to Vercel website deployment

### DIFF
--- a/Website/src/rendering/src/components/PreviewSearch/PreviewSearch.tsx
+++ b/Website/src/rendering/src/components/PreviewSearch/PreviewSearch.tsx
@@ -107,12 +107,16 @@ const PreviewSearch = (props: PreviewSearchProps): JSX.Element => {
 
   window.RFK.ui.useEffect(() => {
     const inputRef = document.querySelector(inputQuerySelector);
-    inputRef.addEventListener('keyup', handleSearchBoxKeyUp);
-    inputRef.addEventListener('focus', handleSearchBoxFocus);
+    if (inputRef) {
+      inputRef.addEventListener('keyup', handleSearchBoxKeyUp);
+      inputRef.addEventListener('focus', handleSearchBoxFocus);
+    }
 
     return () => {
-      inputRef.removeEventListener('keyup', handleSearchBoxKeyUp);
-      inputRef.removeEventListener('focus', handleSearchBoxFocus);
+      if (inputRef) {
+        inputRef.removeEventListener('keyup', handleSearchBoxKeyUp);
+        inputRef.removeEventListener('focus', handleSearchBoxFocus);
+      }
     };
   }, [inputQuerySelector]);
 

--- a/Website/src/rendering/src/components/Products/Shop.tsx
+++ b/Website/src/rendering/src/components/Products/Shop.tsx
@@ -5,6 +5,10 @@ import ShopNavigation, { ShopNavigationProps } from '../Navigation/ShopNavigatio
 import Footer, { FooterProps } from '../Navigation/Footer';
 import HeaderCdpMessageBar from '../HeaderCdpMessageBar';
 import { isCommerceEnabled } from '../../helpers/CommerceHelper';
+import { MerchandisingScripts } from '../../services/MerchandisingService';
+import { Provider } from 'react-redux';
+import reduxStore from '../../redux/store';
+import OcProvider from '../../redux/ocProvider';
 
 export const ShopLayout = (props: PropsWithChildren<unknown>): JSX.Element => {
   const shopNavigationProps = {
@@ -46,7 +50,11 @@ export const ShopLayout = (props: PropsWithChildren<unknown>): JSX.Element => {
 
   // Show shop content if commerce is enabled, otherwise show error message
   const shopContent = isCommerceEnabled ? (
-    <div className="shop-main-container">{props.children}</div>
+    <Provider store={reduxStore}>
+      <OcProvider>
+        <div className="shop-main-container">{props.children}</div>
+      </OcProvider>
+    </Provider>
   ) : (
     <p className="shop-integration-error">
       Shop pages are currently disabled because the commerce integration is not configured
@@ -58,6 +66,8 @@ export const ShopLayout = (props: PropsWithChildren<unknown>): JSX.Element => {
       <Head>
         <link rel="icon" href="/favicon.ico" />
       </Head>
+
+      {MerchandisingScripts}
 
       <header>
         <ShopNavigation {...shopNavigationProps} />

--- a/Website/src/rendering/src/pages/_app.tsx
+++ b/Website/src/rendering/src/pages/_app.tsx
@@ -4,13 +4,9 @@ import { I18nProvider } from 'next-localization';
 import NProgress from 'nprogress';
 import { useEffect } from 'react';
 import Head from 'next/head';
-// DEMO TEAM CUSTOMIZATION - CDP, Discover, and OrcerCloud integrations
+// DEMO TEAM CUSTOMIZATION - CDP integration
 import { CdpScripts, identifyVisitor } from '../services/CdpService';
 import { KeypressHandler } from 'src/services/KeypressHandlerService';
-import { MerchandisingScripts } from 'src/services/MerchandisingService';
-import { Provider } from 'react-redux';
-import reduxStore from '../redux/store';
-import OcProvider from '../redux/ocProvider';
 // END CUSTOMIZATION
 import { config } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
@@ -59,9 +55,8 @@ function App({ Component, pageProps, router }: AppProps): JSX.Element {
         <meta name="description" content="Play! Summit" />
       </Head>
 
-      {/* DEMO TEAM CUSTOMIZATION - CDP/Discover integration. It is important this script is rendered before the <Component> so the CDP calls made on the first page load are successful. */}
+      {/* DEMO TEAM CUSTOMIZATION - CDP integration. It is important this script is rendered before the <Component> so the CDP calls made on the first page load are successful. */}
       {CdpScripts}
-      {MerchandisingScripts}
       {/* END CUSTOMIZATION*/}
 
       {/*
@@ -70,13 +65,7 @@ function App({ Component, pageProps, router }: AppProps): JSX.Element {
         If your app is not multilingual, next-localization and references to it can be removed.
       */}
       <I18nProvider lngDict={dictionary} locale={pageProps.locale}>
-        {/* DEMO TEAM CUSTOMIZATION - OrderCloud integration */}
-        <Provider store={reduxStore}>
-          <OcProvider>
-            <Component {...rest} />
-          </OcProvider>
-        </Provider>
-        {/* END CUSTOMIZATION */}
+        <Component {...rest} />
       </I18nProvider>
     </>
   );

--- a/Website/src/rendering/src/services/DiscoverService.tsx
+++ b/Website/src/rendering/src/services/DiscoverService.tsx
@@ -122,6 +122,13 @@ export const DiscoverScripts: JSX.Element = (
           component: TrendingCategories,
         });
         window.RFK.init();
+        const pushState = history.pushState;
+        history.pushState = (...rest) => {
+          pushState.apply(history, rest);
+          setTimeout(() => {
+            window.RFK.init();
+          }, 0);
+        };
       }}
     />
   </>

--- a/docker/build/init/Jobs/DeployToVercel.cs
+++ b/docker/build/init/Jobs/DeployToVercel.cs
@@ -119,6 +119,13 @@ namespace Sitecore.Demo.Init.Jobs
         {
             var cm = Environment.GetEnvironmentVariable("PUBLIC_HOST_CM");
             var js = Environment.GetEnvironmentVariable("SITECORE_JSS_EDITING_SECRET");
+            var discoverCustomerKey = Environment.GetEnvironmentVariable("DISCOVER_CUSTOMER_KEY");
+            var discoverApiKey = Environment.GetEnvironmentVariable("DISCOVER_API_KEY");
+            var orderCloudBuyerClientId = Environment.GetEnvironmentVariable("ORDERCLOUD_BUYER_CLIENT_ID");
+            var orderCloudBaseApiUrl = Environment.GetEnvironmentVariable("ORDERCLOUD_BASE_API_URL");
+            var orderCloudMiddlewareClientId = Environment.GetEnvironmentVariable("ORDERCLOUD_MIDDLEWARE_CLIENT_ID");
+            var orderCloudMiddlewareClientSecret = Environment.GetEnvironmentVariable("ORDERCLOUD_MIDDLEWARE_CLIENT_SECRET");
+            var orderCloudWebhookHashKey = Environment.GetEnvironmentVariable("ORDERCLOUD_WEBHOOK_HASH_KEY");
             var sourceDirectory = "C:\\app\\rendering";
             var targetDirectory = $"C:\\app\\{ns}-website";
 
@@ -149,6 +156,20 @@ namespace Sitecore.Demo.Init.Jobs
                 $"echo | set /p=\"{cdpApiTargetEndpoint}\" | vercel env add NEXT_PUBLIC_CDP_API_TARGET_ENDPOINT production --token {token} --scope {scope}");
             cmd.Run(
                 $"echo | set /p=\"{cdpProxyUrl}\" | vercel env add NEXT_PUBLIC_CDP_PROXY_URL production --token {token} --scope {scope}");
+            cmd.Run(
+                $"echo | set /p=\"{discoverCustomerKey}\" | vercel env add NEXT_PUBLIC_DISCOVER_CUSTOMER_KEY production --token {token} --scope {scope}");
+            cmd.Run(
+                $"echo | set /p=\"{discoverApiKey}\" | vercel env add NEXT_PUBLIC_DISCOVER_API_KEY production --token {token} --scope {scope}");
+            cmd.Run(
+                $"echo | set /p=\"{orderCloudBuyerClientId}\" | vercel env add NEXT_PUBLIC_ORDERCLOUD_BUYER_CLIENT_ID production --token {token} --scope {scope}");
+            cmd.Run(
+                $"echo | set /p=\"{orderCloudBaseApiUrl}\" | vercel env add NEXT_PUBLIC_ORDERCLOUD_BASE_API_URL production --token {token} --scope {scope}");
+            cmd.Run(
+                $"echo | set /p=\"{orderCloudMiddlewareClientId}\" | vercel env add ORDERCLOUD_MIDDLEWARE_CLIENT_ID production --token {token} --scope {scope}");
+            cmd.Run(
+                $"echo | set /p=\"{orderCloudMiddlewareClientSecret}\" | vercel env add ORDERCLOUD_MIDDLEWARE_CLIENT_SECRET production --token {token} --scope {scope}");
+            cmd.Run(
+                $"echo | set /p=\"{orderCloudWebhookHashKey}\" | vercel env add OC_WEBHOOK_HASH_KEY production --token {token} --scope {scope}");
 
             // Deploy project files
             var output = cmd.Run($"vercel --confirm --debug --prod --no-clipboard --token {token} --scope {scope} --regions {region}");


### PR DESCRIPTION
Plus:
- Move commerce integration from the app to the ShopLayout to avoid errors on the summit side in case one of the commerce system is unavailable.
- Re-initialize Discover on Next.js route change.
- Add robustness to PreviewSearch component.