### PR TITLE
AB#7610 Allow orders to be loaded in Headstart Seller UI

### DIFF
--- a/Website/src/rendering/src/components/Account/OrderDetails.tsx
+++ b/Website/src/rendering/src/components/Account/OrderDetails.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/router';
 import {
   BuyerCreditCard,
   IntegrationEvents,
-  Me,
   OrderWorksheet,
   Payments,
   ShipMethod,

--- a/Website/src/rendering/src/components/Account/OrderDetails.tsx
+++ b/Website/src/rendering/src/components/Account/OrderDetails.tsx
@@ -28,9 +28,8 @@ const OrderDetails = (): JSX.Element => {
 
       const [fetchedOrder, fetchedPayment] = await Promise.all([orderPromise, paymentPromise]);
 
-      let creditCardPromise: Promise<BuyerCreditCard>;
       if (fetchedPayment?.Items?.length > 0) {
-        creditCardPromise = Me.GetCreditCard(fetchedPayment.Items[0].CreditCardID);
+        setCreditCard(fetchedPayment.Items[0].xp.CreditCard);
       }
 
       if (fetchedOrder) {
@@ -45,13 +44,6 @@ const OrderDetails = (): JSX.Element => {
 
         if (selectedShipMethod) {
           setShipMethod(selectedShipMethod);
-        }
-      }
-
-      if (creditCardPromise) {
-        const fetchedCreditCard = await creditCardPromise;
-        if (fetchedCreditCard) {
-          setCreditCard(fetchedCreditCard);
         }
       }
     };

--- a/Website/src/rendering/src/components/Products/ProductDetailsContent.tsx
+++ b/Website/src/rendering/src/components/Products/ProductDetailsContent.tsx
@@ -179,6 +179,20 @@ const ProductDetailsContent = ({
           ProductID: product.ID,
           Quantity: quantity,
           Specs: specValues,
+          xp: {
+            StatusByQuantity: {
+              Submitted: quantity,
+              Open: 0,
+              Backordered: 0,
+              Canceled: 0,
+              CancelRequested: 0,
+              CancelDenied: 0,
+              Returned: 0,
+              ReturnRequested: 0,
+              ReturnDenied: 0,
+              Complete: 0,
+            },
+          },
         })
       );
       setIsLoading(false);

--- a/Website/src/rendering/src/models/ordercloud/DLineItem.ts
+++ b/Website/src/rendering/src/models/ordercloud/DLineItem.ts
@@ -29,5 +29,5 @@ export interface DLineItemXp {
   // add custom xp properties required for this project here
   IsGift?: boolean;
   Comment?: string;
-  StatusByQuantity: DStatusByQuantity;
+  StatusByQuantity?: DStatusByQuantity;
 }

--- a/Website/src/rendering/src/models/ordercloud/DLineItem.ts
+++ b/Website/src/rendering/src/models/ordercloud/DLineItem.ts
@@ -12,8 +12,22 @@ export type DLineItem = LineItem<
   DShipFromAddress
 >;
 
+type DStatusByQuantity = {
+  Submitted: number;
+  Open: number;
+  Backordered: number;
+  Canceled: number;
+  CancelRequested: number;
+  CancelDenied: number;
+  Returned: number;
+  ReturnRequested: number;
+  ReturnDenied: number;
+  Complete: number;
+};
+
 export interface DLineItemXp {
   // add custom xp properties required for this project here
   IsGift?: boolean;
   Comment?: string;
+  StatusByQuantity: DStatusByQuantity;
 }

--- a/Website/src/rendering/src/redux/ocCurrentCart/index.ts
+++ b/Website/src/rendering/src/redux/ocCurrentCart/index.ts
@@ -224,6 +224,7 @@ export const createLineItem = createOcAsyncThunk<RequiredDeep<DOrderWorksheet>, 
       await LineItems.Create<DLineItem>('All', orderId, request);
     } else {
       request.Quantity += lineItemAlreadyInCart.Quantity;
+      request.xp.StatusByQuantity.Submitted += lineItemAlreadyInCart.Quantity;
       await LineItems.Patch<DLineItem>('All', orderId, lineItemAlreadyInCart.ID, request);
     }
 


### PR DESCRIPTION
Set line items StatusByQuantity for Headstart Seller UI to load the orders without errors.
In order history, use the credit card from the payment XP as it will not always be a saved payment method.