### PR TITLE
Feature/add recommendations to vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,4 @@
+{
+    "recommendations": ["ms-azuretools.vscode-docker", "dbaeumer.vscode-eslint", "yzhang.markdown-all-in-one", "davidanson.vscode-markdownlint",
+        "esbenp.prettier-vscode", "rvest.vs-code-prettier-eslint", "stylelint.vscode-stylelint", "bradlc.vscode-tailwindcss", "shardulm94.trailing-spaces", "rbbit.typescript-hero", "redhat.vscode-yaml" ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,15 @@
 {
-    "recommendations": ["ms-azuretools.vscode-docker", "dbaeumer.vscode-eslint", "yzhang.markdown-all-in-one", "davidanson.vscode-markdownlint",
-        "esbenp.prettier-vscode", "rvest.vs-code-prettier-eslint", "stylelint.vscode-stylelint", "bradlc.vscode-tailwindcss", "shardulm94.trailing-spaces", "rbbit.typescript-hero", "redhat.vscode-yaml" ]
+  "recommendations": [
+    "ms-azuretools.vscode-docker",
+    "dbaeumer.vscode-eslint",
+    "yzhang.markdown-all-in-one",
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "rvest.vs-code-prettier-eslint",
+    "stylelint.vscode-stylelint",
+    "bradlc.vscode-tailwindcss",
+    "shardulm94.trailing-spaces",
+    "rbbit.typescript-hero",
+    "redhat.vscode-yaml"
+  ]
 }

--- a/Website/.vscode/extensions.json
+++ b/Website/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-docker",
+    "dbaeumer.vscode-eslint",
+    "yzhang.markdown-all-in-one",
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "rvest.vs-code-prettier-eslint",
+    "stylelint.vscode-stylelint",
+    "bradlc.vscode-tailwindcss",
+    "shardulm94.trailing-spaces",
+    "rbbit.typescript-hero",
+    "redhat.vscode-yaml"
+  ]
+}

--- a/Website/src/rendering/.vscode/extensions.json
+++ b/Website/src/rendering/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-docker",
+    "dbaeumer.vscode-eslint",
+    "yzhang.markdown-all-in-one",
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "rvest.vs-code-prettier-eslint",
+    "stylelint.vscode-stylelint",
+    "bradlc.vscode-tailwindcss",
+    "shardulm94.trailing-spaces",
+    "rbbit.typescript-hero",
+    "redhat.vscode-yaml"
+  ]
+}

--- a/compare-synced-files.ps1
+++ b/compare-synced-files.ps1
@@ -29,14 +29,14 @@ $syncFilesMappings = @(
         ".\Website\src\rendering\.vscode\settings.json",
         ".\demo\experience\cdp\guestDataGenerator\.vscode\settings.json"
     ),
-    @{
+    @(
         ".\.vscode\extensions.json",
         ".\Website\.vscode\extensions.json",
         ".\Website\src\rendering\.vscode\extensions.json",
         ".\demo\experience\cdp\guestDataGenerator\.vscode\extensions.json",
         ".\kiosk\.vscode\extensions.json",
         ".\tv\.vscode\extensions.json"
-    }
+    )
 )
 
 foreach ($syncFilesMapping in $syncFilesMappings) {

--- a/compare-synced-files.ps1
+++ b/compare-synced-files.ps1
@@ -28,7 +28,15 @@ $syncFilesMappings = @(
         ".\tv\.vscode\settings.json",
         ".\Website\src\rendering\.vscode\settings.json",
         ".\demo\experience\cdp\guestDataGenerator\.vscode\settings.json"
-    )
+    ),
+    @{
+        ".\.vscode\extensions.json",
+        ".\Website\.vscode\extensions.json",
+        ".\Website\src\rendering\.vscode\extensions.json",
+        ".\demo\experience\cdp\guestDataGenerator\.vscode\extensions.json",
+        ".\kiosk\.vscode\extensions.json",
+        ".\tv\.vscode\extensions.json"
+    }
 )
 
 foreach ($syncFilesMapping in $syncFilesMappings) {

--- a/demo/experience/cdp/guestDataGenerator/.vscode/extensions.json
+++ b/demo/experience/cdp/guestDataGenerator/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-docker",
+    "dbaeumer.vscode-eslint",
+    "yzhang.markdown-all-in-one",
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "rvest.vs-code-prettier-eslint",
+    "stylelint.vscode-stylelint",
+    "bradlc.vscode-tailwindcss",
+    "shardulm94.trailing-spaces",
+    "rbbit.typescript-hero",
+    "redhat.vscode-yaml"
+  ]
+}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,7 +29,7 @@ This can be done by:
 
 ### Target Branch
 
-Pull requests must use the `contrib` branch as the target branch.
+Pull requests must use the `develop` branch as the target branch.
 
 ### Title
 

--- a/kiosk/.vscode/extensions.json
+++ b/kiosk/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-docker",
+    "dbaeumer.vscode-eslint",
+    "yzhang.markdown-all-in-one",
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "rvest.vs-code-prettier-eslint",
+    "stylelint.vscode-stylelint",
+    "bradlc.vscode-tailwindcss",
+    "shardulm94.trailing-spaces",
+    "rbbit.typescript-hero",
+    "redhat.vscode-yaml"
+  ]
+}

--- a/tv/.vscode/extensions.json
+++ b/tv/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-docker",
+    "dbaeumer.vscode-eslint",
+    "yzhang.markdown-all-in-one",
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "rvest.vs-code-prettier-eslint",
+    "stylelint.vscode-stylelint",
+    "bradlc.vscode-tailwindcss",
+    "shardulm94.trailing-spaces",
+    "rbbit.typescript-hero",
+    "redhat.vscode-yaml"
+  ]
+}


### PR DESCRIPTION
I added the "extensions.json" file to .vscode. The recommendations from the documentation will automatically show up in the vscode extensions overview:

![image](https://user-images.githubusercontent.com/11842067/181707214-822d02b5-3bb9-4f3c-8ef2-554248a5e834.png)

Also changed the contibution branch from "contrib" to "develop" after a short discussion with Jeff L'Heureux, as that is the active branch for contributions (according to him)
