### PR TITLE
AB#8411 - disabled Sitecore_License env var

### DIFF
--- a/.env
+++ b/.env
@@ -61,10 +61,6 @@ LOCAL_DEPLOY_PATH=.\Website\deploy
 LOCAL_DATA_PATH=.\docker\data
 HOST_LICENSE_FOLDER=
 
-# Because we are using a mounted license file, this value can be empty.
-# Included here to suppress 'variable is not set' warning from docker-compose.
-SITECORE_LICENSE=
-
 # The isolation mode for Sitecore containers.
 # Compatibility of isolation mode depends on the Host and Container OS versions.
 ISOLATION=default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       Sitecore_Sitecore__IdentityServer__CertificateRawData: ${SITECORE_ID_CERTIFICATE}
       Sitecore_Sitecore__IdentityServer__PublicOrigin: https://${ID_HOST}
       Sitecore_Sitecore__IdentityServer__CertificateRawDataPassword: ${SITECORE_ID_CERTIFICATE_PASSWORD}
-      Sitecore_License: ${SITECORE_LICENSE}
+      # Sitecore_License: ${SITECORE_LICENSE}
     healthcheck:
       test: ["CMD", "pwsh", "-command", "C:/Healthchecks/Healthcheck.ps1"]
       timeout: 300s
@@ -101,7 +101,7 @@ services:
       Sitecore_AppSettings_Telerik.AsyncUpload.ConfigurationEncryptionKey: ${TELERIK_ENCRYPTION_KEY}
       Sitecore_AppSettings_Telerik.Upload.ConfigurationHashKey: ${TELERIK_ENCRYPTION_KEY}
       Sitecore_AppSettings_Telerik.Web.UI.DialogParametersEncryptionKey: ${TELERIK_ENCRYPTION_KEY}
-      Sitecore_License: ${SITECORE_LICENSE}
+      # Sitecore_License: ${SITECORE_LICENSE}
       Sitecore_Identity_Server_Authority: https://${ID_HOST}
       Sitecore_Identity_Server_InternalAuthority: http://id
       Sitecore_Identity_Server_CallbackAuthority: https://${CM_HOST}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       Sitecore_Sitecore__IdentityServer__CertificateRawData: ${SITECORE_ID_CERTIFICATE}
       Sitecore_Sitecore__IdentityServer__PublicOrigin: https://${ID_HOST}
       Sitecore_Sitecore__IdentityServer__CertificateRawDataPassword: ${SITECORE_ID_CERTIFICATE_PASSWORD}
+      # DEMO TEAM CUSTOMIZATION - Configure for a mounted license file instead of using SITECORE_LICENSE
       # Sitecore_License: ${SITECORE_LICENSE}
     healthcheck:
       test: ["CMD", "pwsh", "-command", "C:/Healthchecks/Healthcheck.ps1"]
@@ -101,6 +102,7 @@ services:
       Sitecore_AppSettings_Telerik.AsyncUpload.ConfigurationEncryptionKey: ${TELERIK_ENCRYPTION_KEY}
       Sitecore_AppSettings_Telerik.Upload.ConfigurationHashKey: ${TELERIK_ENCRYPTION_KEY}
       Sitecore_AppSettings_Telerik.Web.UI.DialogParametersEncryptionKey: ${TELERIK_ENCRYPTION_KEY}
+      # DEMO TEAM CUSTOMIZATION - Configure for a mounted license file instead of using SITECORE_LICENSE
       # Sitecore_License: ${SITECORE_LICENSE}
       Sitecore_Identity_Server_Authority: https://${ID_HOST}
       Sitecore_Identity_Server_InternalAuthority: http://id

--- a/docker/build-and-push-images.yml
+++ b/docker/build-and-push-images.yml
@@ -178,7 +178,7 @@ stages:
         script: |
           $sitecoreRegistry = "$(sitecore.container.registry)"
 
-          az login -u "$(sitecore.container.registry.username)" -p "$(sitecore.container.registry.password)" -t "$(sitecore.container.registry.tenant)"
+          az login -u "$(sitecore.container.registry.username)" -p "${env:SITECORE_CONTAINER_REGISTRY_PASSWORD}" -t "$(sitecore.container.registry.tenant)"
 
           if ("$sitecoreRegistry" -ne "scr.sitecore.com/"){
             az acr login -n "$(sitecore.container.registry.short)"


### PR DESCRIPTION
The initialization scripts don't base64 encode the Sitecore License. Instead, the demo implementation relies on mounting the folder containing `license.xml` in the host. 

Since it isn't being explicitly set in the `.env` file, Docker will grab that variable from the host machine, if present. 

The environment variable will take precedence over a explicit license file. This can lead to the demo instance failing to start if the host machine already has `SITECORE_LICENSE` set for a different project running a different version of Sitecore. 

Commenting it out, rather than removing it outright, keeps it consistent with XMCloud Demo:
https://github.com/blipson89/Sitecore.Demo.XmCloud.PlaySummit/blob/main/docker-compose.yml#L97